### PR TITLE
Add the "pdashv2" URL prefix

### DIFF
--- a/web-server/pdash/.webpackrc.js
+++ b/web-server/pdash/.webpackrc.js
@@ -1,9 +1,6 @@
 const path = require('path');
 
 export default {
-  define: {
-    'process.env.CONFIG': process.env.CONFIG
-  },
   entry: 'src/index.js',
   extraBabelPlugins: [['import', { libraryName: 'antd', libraryDirectory: 'es', style: true }]],
   env: {
@@ -27,6 +24,6 @@ export default {
     javascriptEnabled: true,
   },
   disableDynamicImport: true,
-  publicPath: '/',
+  publicPath: '/pdashv2',
   hash: true,
 };

--- a/web-server/pdash/package.json
+++ b/web-server/pdash/package.json
@@ -5,11 +5,9 @@
   "private": true,
   "scripts": {
     "precommit": "npm run lint-staged",
-    "start:dev": "cross-env CONFIG=prod ESLINT=none roadhog dev",
-    "start:prod": "cross-env CONFIG=prod ESLINT=none roadhog dev",
+    "start": "cross-env ESLINT=none roadhog dev",
     "start:no-proxy": "cross-env NO_PROXY=true ESLINT=none roadhog dev",
-    "build:stag": "cross-env CONFIG=stag ESLINT=none roadhog build",
-    "build:prod": "cross-env CONFIG=prod ESLINT=none roadhog build",
+    "build": "cross-env ESLINT=none roadhog build",
     "site": "roadhog-api-doc static && gh-pages -d dist",
     "analyze": "cross-env ANALYZE=true roadhog build",
     "lint:style": "stylelint \"src/**/*.less\" --syntax less",

--- a/web-server/pdash/src/index.ejs
+++ b/web-server/pdash/src/index.ejs
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>PDash</title>
-  <link rel="icon" href="/favicon.png" type="image/x-icon">
+  <link rel="icon" href="/pdashv2/favicon.png" type="image/x-icon">
   <script src="https://cdn.bootcss.com/rollbar.js/2.4.0/rollbar.min.js"></script>
   <script src="https://gw.alipayobjects.com/os/antv/assets/data-set/0.8.7/data-set.min.js"></script>
 </head>

--- a/web-server/pdash/src/services/global.js
+++ b/web-server/pdash/src/services/global.js
@@ -1,7 +1,8 @@
 import request from '../utils/request';
 
 export async function queryDatastoreConfig() {
-  return request('//' + window.location.host + '/' + process.env.CONFIG + '.config.json', {
+  // Note that window.location.pathname should have a trailing slash already.
+  return request(window.location.pathname + 'config.json', {
     method: 'GET',
   });
 }


### PR DESCRIPTION
Added the "pdashv2" URL prefix via .webpackrc.js publicPath, updated the
index.html template (src/index.ejs) to reference the pdashv2 prefix for
the favicon.png file, and updated the reference to the config file off of
the current web pages pathname.